### PR TITLE
[30]: Enable post to FB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ dist
 
 # Idea
 .idea
+
+# API keys
+secrets.go

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ type ContentResponseMeta struct {
 }
 
 type Content struct {
-	Body string `json:"content_body"`
+	ContentBody string `json:"content_body"`
 }
 
 type ContentResponse struct {

--- a/server/server.go
+++ b/server/server.go
@@ -37,9 +37,20 @@ func main() {
 		return c.JSON(http.StatusOK, res)
 	})
 
-  e.POST("/postTest", func(c echo.Context) error {
-    reqParams := c.QueryParams()
-    return c.JSON(http.StatusOK, reqParams)
+  
+  type Content struct {
+    Username string `json:"username"`
+    ContentID string `json:"id"`
+    ContentBody string `json:"content_body"`
+  }
+
+  e.POST("/postTest", func(c echo.Context) (err error) {
+    content := new(Content)
+    if err = c.Bind(content); err != nil {
+      return
+    }
+
+    return c.JSON(http.StatusOK, content)
   })
 
 	e.Logger.Fatal(e.Start(":1323"))

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,8 @@ func main() {
 	})
 
   e.POST("/postTest", func(c echo.Context) error {
-    return c.JSON(http.StatusOK, res)
+    reqParams := c.QueryParams()
+    return c.JSON(http.StatusOK, reqParams)
   })
 
 	e.Logger.Fatal(e.Start(":1323"))

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -18,13 +17,6 @@ type Content struct {
 type ContentResponse struct {
 	Meta ContentResponseMeta `json:"meta"`
 	Data []Content `json:"data"`
-}
-
-func handlePostReq(w http.ResponseWriter, req *http.Request) {
-  req.ParseForm()
-  fmt.Println("id", req.Form["id"])
-  req.Form.Get("id")
-  fmt.Println(req.PostFormValue("id"))
 }
 
 func main() {
@@ -45,8 +37,9 @@ func main() {
 		return c.JSON(http.StatusOK, res)
 	})
 
-  http.HandleFunc("/postTest", handlePostReq)
+  e.POST("/postTest", func(c echo.Context) error {
+    return c.JSON(http.StatusOK, res)
+  })
 
-	// e.Logger.Fatal(e.Start(":1323"))
-  e.Logger.Fatal(http.ListenAndServe(":1323", nil))
+	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 )
@@ -19,6 +22,23 @@ type ContentResponse struct {
 	Data []Content `json:"data"`
 }
 
+func handlePostReq() {
+	url := "" // FB API
+
+	payload := strings.NewReader("name=test&otherThing=test2")
+
+	req, _ := http.NewRequest("POST", url, payload)
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("cache-control", "no-cache")
+
+  res, _ := http.DefaultClient.Do(req)
+
+  defer res.Body.Close()
+  body, _ := ioutil.ReadAll(res.Body)
+
+  fmt.Println(string(body))
+}
 
 func main() {
 	e := echo.New()

--- a/server/server.go
+++ b/server/server.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v4"
 )
@@ -22,22 +20,11 @@ type ContentResponse struct {
 	Data []Content `json:"data"`
 }
 
-func handlePostReq() {
-	url := "" // FB API
-
-	payload := strings.NewReader("name=test&otherThing=test2")
-
-	req, _ := http.NewRequest("POST", url, payload)
-
-	req.Header.Add("content-type", "application/x-www-form-urlencoded")
-	req.Header.Add("cache-control", "no-cache")
-
-  res, _ := http.DefaultClient.Do(req)
-
-  defer res.Body.Close()
-  body, _ := ioutil.ReadAll(res.Body)
-
-  fmt.Println(string(body))
+func handlePostReq(w http.ResponseWriter, req *http.Request) {
+  req.ParseForm()
+  fmt.Println("id", req.Form["id"])
+  req.Form.Get("id")
+  fmt.Println(req.PostFormValue("id"))
 }
 
 func main() {
@@ -58,5 +45,8 @@ func main() {
 		return c.JSON(http.StatusOK, res)
 	})
 
-	e.Logger.Fatal(e.Start(":1323"))
+  http.HandleFunc("/postTest", handlePostReq)
+
+	// e.Logger.Fatal(e.Start(":1323"))
+  e.Logger.Fatal(http.ListenAndServe(":1323", nil))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,22 @@ type ContentResponse struct {
 	Data []Content `json:"data"`
 }
 
+type FBStruct struct {
+  ID string `json:"id"`
+}
+
+func requestFacebook(c echo.Context) error {
+  fbID := c.QueryParam("id")
+
+  fmt.Println(c.ParamNames())
+  fmt.Println(c.QueryParams())
+  fmt.Println(c.Request())
+
+  return c.JSON(http.StatusOK, map[string]string {
+    "id": fbID,
+  })
+}
+
 func main() {
 	e := echo.New()
 
@@ -28,8 +44,8 @@ func main() {
 		return c.File("../templates/index.html")
 		
 	})
-
-	res := &ContentResponse{
+	
+  res := &ContentResponse{
 		Meta: ContentResponseMeta{},
 		Data: []Content{},
 	}
@@ -47,6 +63,10 @@ func main() {
 
     return c.JSON(http.StatusOK, content)
   })
+
+  // FB
+  postURL := fmt.Sprintf("https://graph.facebook.com/%s/feed?message=testFromGo&access_token=%s", FB_PAGE_ID, FB_PAGE_ACCESS_TOKEN)
+  e.POST(postURL, requestFacebook)
 
 	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -24,24 +24,24 @@ type ContentResponse struct {
 	Data []Content `json:"data"`
 }
 
-func requestFacebook(c echo.Context) error {
+func requestPOSTFacebookContent(c echo.Context) error {
   postURL := fmt.Sprintf("https://graph.facebook.com/%s/feed", FB_PAGE_ID)
 
   postBody, _ := json.Marshal(map[string]string{
     "message":  "Hello from Go!",
     "access_token": FB_PAGE_ACCESS_TOKEN,
   })
-  reqBody := bytes.NewBuffer(postBody)
+  requestBody := bytes.NewBuffer(postBody)
 
-  resp, err := http.Post(postURL, "application/json", reqBody)
+  response, err := http.Post(postURL, "application/json", requestBody)
 
   if err != nil {
     log.Fatalf("An Error Occured %v", err)
   }
   
-  defer resp.Body.Close()
+  defer response.Body.Close()
 
-  body, err := ioutil.ReadAll(resp.Body)
+  body, err := ioutil.ReadAll(response.Body)
   
   if err != nil {
     log.Fatalln(err)
@@ -69,7 +69,7 @@ func main() {
 		return c.JSON(http.StatusOK, res)
 	})
 
-  e.POST("/content", requestFacebook)
+  e.POST("/content", requestPOSTFacebookContent)
 
 	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -37,17 +38,11 @@ func main() {
 		return c.JSON(http.StatusOK, res)
 	})
 
-  
-  type Content struct {
-    Username string `json:"username"`
-    ContentID string `json:"id"`
-    ContentBody string `json:"content_body"`
-  }
-
-  e.POST("/postTest", func(c echo.Context) (err error) {
+  e.POST("/content", func(c echo.Context) (err error) {
     content := new(Content)
     if err = c.Bind(content); err != nil {
-      return
+      fmt.Printf("There was an error processing the POST request. Error: %s", err.Error())
+      return err
     }
 
     return c.JSON(http.StatusOK, content)

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ type ContentResponseMeta struct {
 }
 
 type Content struct {
-	Body string `json:"body"`
+	Body string `json:"content_body"`
 }
 
 type ContentResponse struct {


### PR DESCRIPTION
<!--
Before writing a pull request, make sure related commits are prefixed with the GitHub issue number.  For example, if one were making a PR for this issue: https://github.com/mskalandunas/Robin/issues/3, they'd commit the following:

git commit -m '[3]: Create pull request template' 

and create a pull request with a title including the issue number, like:

[3]: Create pull request template

This helps reviewers and future developers looking back at the source control history gain context for what the change is and why it was introduced.
-->

# Description
Issue: https://github.com/mskalandunas/Robin/issues/30
Description: Using Postman to send a POST request to the /content route, a function has been added to handle sending an HTTP POST request to the Facebook Graph API to post on a Facebook Page.

Right now the `message` parameter as part of the request body is hard-coded (which might result in an error if you try to send multiple requests with the same `message` value), but that will be changed in the future once we start handling information sent from the client side.
<!---
The description should contain the following:
- A link to the GitHub issue this pull request is resolving
- A description of what's being done to resolve the issue.  

The resolution description could be a sentence, several bullets, or whatever suffices to accurately describe the gist of the changes.
-->

# Screenshots/GIFS
<!---
Include screenshots and/or gifs if the UI is updated in this revision.
--->

# Reviewers
@mskalandunas 
<!--
Tag relevant reviewers
-->